### PR TITLE
Improve Emojibase usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased]
 
+- When setting `emojiVersion` on `EmojiPicker.Root`, this version of Emojibase’s data will be fetched instead of `latest`.
+- Add `emojibaseUrl` prop on `EmojiPicker.Root` to allow choosing where Emojibase’s data is fetched from: another CDN, self-hosted files, etc.
+
 ## [0.1.1] - 2025-03-31
 
 - Fix `EmojiPicker.Search` controlled value not updating search results when updated externally. (e.g. other input, manually, etc)

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,8 @@
         "turbo": "^2.4.4",
         "typescript": "^5.8.2",
         "vitest": "^3.0.8",
-        "vitest-browser-react": "^0.1.1"
+        "vitest-browser-react": "^0.1.1",
+        "vitest-fetch-mock": "^0.4.5"
       },
       "peerDependencies": {
         "react": "^18 || ^19"
@@ -10757,6 +10758,18 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vitest-fetch-mock": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/vitest-fetch-mock/-/vitest-fetch-mock-0.4.5.tgz",
+      "integrity": "sha512-nhWdCQIGtaSEUVl96pMm0WggyDGPDv5FUy/Q9Hx3cs2RGmh3Q/uRsLClGbdG3kXBkJ3br5yTUjB2MeW25TwdOA==",
+      "dev": true,
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "vitest": ">=2.0.0"
       }
     },
     "node_modules/w3c-xmlserializer": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,8 @@
     "turbo": "^2.4.4",
     "typescript": "^5.8.2",
     "vitest": "^3.0.8",
-    "vitest-browser-react": "^0.1.1"
+    "vitest-browser-react": "^0.1.1",
+    "vitest-fetch-mock": "^0.4.5"
   },
   "bugs": {
     "url": "https://github.com/liveblocks/frimousse/issues"

--- a/site/src/app/sitemap.ts
+++ b/site/src/app/sitemap.ts
@@ -1,5 +1,5 @@
-import type { MetadataRoute } from "next";
 import { config } from "@/config";
+import type { MetadataRoute } from "next";
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   "use cache";

--- a/site/src/app/styles.css
+++ b/site/src/app/styles.css
@@ -268,14 +268,17 @@
     @apply text-sm;
 
     &:not(:last-child) {
-      @apply mb-1;
+      @apply mb-2;
     }
   }
 }
 
 @utility scrollbar-thumb-* {
   --scrollbar-thumb-alpha: calc(--modifier(integer) * 1%);
-  --scrollbar-thumb: --alpha(--value(--color-\*, [color]) / var(--scrollbar-thumb-alpha, 100%));
+  --scrollbar-thumb: --alpha(
+    --value(--color-\*, [color]) /
+    var(--scrollbar-thumb-alpha, 100%)
+  );
 
   scrollbar-color: var(--scrollbar-thumb) var(--scrollbar-track, transparent);
 
@@ -287,7 +290,10 @@
 
 @utility scrollbar-track-* {
   --scrollbar-track-alpha: calc(--modifier(integer) * 1%);
-  --scrollbar-track: --alpha(--value(--color-\*, [color]) / var(--scrollbar-track-alpha, 100%));
+  --scrollbar-track: --alpha(
+    --value(--color-\*, [color]) /
+    var(--scrollbar-track-alpha, 100%)
+  );
 
   scrollbar-color: var(
       --scrollbar-thumb,

--- a/site/src/components/sections/docs.tsx
+++ b/site/src/components/sections/docs.tsx
@@ -323,7 +323,45 @@ export function Docs({
               Emoji version
             </a>{" "}
             to use, to manually control which emojis are visible regardless of
-            the current browser's supported Emoji versions.
+            the current browser’s supported Emoji versions.
+          </p>
+        </PropertiesListRow>
+        <PropertiesListRow
+          defaultValue={`"https://cdn.jsdelivr.net/npm/emojibase-data"`}
+          name="emojibaseUrl"
+          type="string"
+        >
+          <p>
+            The base URL of where the{" "}
+            <a
+              href="https://emojibase.dev/docs/datasets/"
+              rel="noreferrer"
+              target="_blank"
+            >
+              Emojibase data
+            </a>{" "}
+            should be fetched from, used as follows:{" "}
+            <code>
+              ${"{"}emojibaseUrl{"}"}/{"{"}locale{"}"}/{"{"}file{"}"}.json
+            </code>
+            . (e.g.{" "}
+            <code>
+              ${"{"}emojibaseUrl{"}"}/en/data.json
+            </code>
+            ).
+          </p>
+          <p>
+            The URL can be set to another CDN hosting the{" "}
+            <a
+              href="https://www.npmjs.com/package/emojibase-data"
+              rel="noreferrer"
+              target="_blank"
+            >
+              <code>emojibase-data</code>
+            </a>{" "}
+            package and its raw JSON files, or to a self-hosted location. When
+            self-hosting with a single locale (e.g. <code>en</code>), only that
+            locale’s directory needs to be hosted instead of the entire package.
           </p>
         </PropertiesListRow>
         <PropertiesListBasicRow>

--- a/src/components/emoji-picker.tsx
+++ b/src/components/emoji-picker.tsx
@@ -65,7 +65,8 @@ import { useStableCallback } from "../utils/use-stable-callback";
 
 function EmojiPickerDataHandler({
   emojiVersion,
-}: { emojiVersion: number | undefined }) {
+  emojibaseUrl,
+}: Pick<EmojiPickerRootProps, "emojiVersion" | "emojibaseUrl">) {
   const [emojiData, setEmojiData] = useState<EmojiData | undefined>(undefined);
   const store = useEmojiPickerStore();
   const locale = useSelectorKey(store, "locale");
@@ -77,7 +78,7 @@ function EmojiPickerDataHandler({
     const controller = new AbortController();
     const signal = controller.signal;
 
-    getEmojiData(locale, emojiVersion, signal)
+    getEmojiData({ locale, emojiVersion, emojibaseUrl, signal })
       .then((data) => {
         setEmojiData(data);
       })
@@ -90,7 +91,7 @@ function EmojiPickerDataHandler({
     return () => {
       controller.abort();
     };
-  }, [emojiVersion, locale]);
+  }, [emojiVersion, emojibaseUrl, locale]);
 
   useEffect(() => {
     if (!emojiData) {
@@ -143,6 +144,7 @@ const EmojiPickerRoot = forwardRef<HTMLDivElement, EmojiPickerRootProps>(
       skinTone = "none",
       onEmojiSelect = noop,
       emojiVersion,
+      emojibaseUrl,
       onFocusCapture,
       onBlurCapture,
       children,
@@ -461,7 +463,10 @@ const EmojiPickerRoot = forwardRef<HTMLDivElement, EmojiPickerRootProps>(
         }
       >
         <EmojiPickerStoreProvider store={store}>
-          <EmojiPickerDataHandler emojiVersion={emojiVersion} />
+          <EmojiPickerDataHandler
+            emojiVersion={emojiVersion}
+            emojibaseUrl={emojibaseUrl}
+          />
           {children}
         </EmojiPickerStoreProvider>
       </div>

--- a/src/data/__tests__/emoji.test.ts
+++ b/src/data/__tests__/emoji.test.ts
@@ -15,17 +15,11 @@ describe("getEmojiData", () => {
 
   it("should support aborting the request", async () => {
     const controller = new AbortController();
-    const promise = getEmojiData(
-      "en",
-      Number.POSITIVE_INFINITY,
-      controller.signal,
-    );
+    const promise = getEmojiData("en", undefined, controller.signal);
 
     controller.abort();
 
-    const data = await promise;
-
-    expect(data).toBeDefined();
+    await expect(promise).rejects.toThrow(DOMException);
   });
 
   it("should support a specific emoji version", async () => {

--- a/src/data/__tests__/emoji.test.ts
+++ b/src/data/__tests__/emoji.test.ts
@@ -8,14 +8,14 @@ describe("getEmojiData", () => {
   });
 
   it("should return the emoji data", async () => {
-    const data = await getEmojiData("en");
+    const data = await getEmojiData({ locale: "en" });
 
     expect(data).toBeDefined();
   });
 
   it("should support aborting the request", async () => {
     const controller = new AbortController();
-    const promise = getEmojiData("en", undefined, controller.signal);
+    const promise = getEmojiData({ locale: "en", signal: controller.signal });
 
     controller.abort();
 
@@ -23,14 +23,14 @@ describe("getEmojiData", () => {
   });
 
   it("should support a specific emoji version", async () => {
-    const data = await getEmojiData("en", 5);
+    const data = await getEmojiData({ locale: "en", emojiVersion: 5 });
 
     expect(data).toBeDefined();
     expect(data.emojis.every((emoji) => emoji.version <= 5)).toBe(true);
   });
 
   it("should save data locally", async () => {
-    await getEmojiData("en");
+    await getEmojiData({ locale: "en" });
 
     const localStorageData = localStorage.getItem(LOCAL_DATA_KEY("en"));
     const sessionStorageData = sessionStorage.getItem(SESSION_METADATA_KEY);
@@ -40,13 +40,13 @@ describe("getEmojiData", () => {
   });
 
   it("should use local data if available from a previous session", async () => {
-    await getEmojiData("en");
+    await getEmojiData({ locale: "en" });
 
     sessionStorage.clear();
 
     const fetchSpy = vi.spyOn(globalThis, "fetch");
 
-    await getEmojiData("en");
+    await getEmojiData({ locale: "en" });
 
     expect(fetchSpy).toHaveBeenCalledTimes(2);
     expect(fetchSpy.mock.calls[0]).toEqual([
@@ -63,7 +63,7 @@ describe("getEmojiData", () => {
     localStorage.setItem(LOCAL_DATA_KEY("en"), "{}");
     sessionStorage.setItem(SESSION_METADATA_KEY, "{}");
 
-    await getEmojiData("en");
+    await getEmojiData({ locale: "en" });
 
     const localStorageData = localStorage.getItem(LOCAL_DATA_KEY("en"));
     const sessionStorageData = sessionStorage.getItem(SESSION_METADATA_KEY);

--- a/src/data/__tests__/emoji.test.ts
+++ b/src/data/__tests__/emoji.test.ts
@@ -22,11 +22,36 @@ describe("getEmojiData", () => {
     await expect(promise).rejects.toThrow(DOMException);
   });
 
-  it("should support a specific emoji version", async () => {
+  it("should support a specific Emoji version", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
     const data = await getEmojiData({ locale: "en", emojiVersion: 5 });
 
     expect(data).toBeDefined();
     expect(data.emojis.every((emoji) => emoji.version <= 5)).toBe(true);
+
+    expect(fetchSpy.mock.calls[0]?.[0]).toEqual(
+      "https://cdn.jsdelivr.net/npm/emojibase-data@5/en/data.json",
+    );
+    expect(fetchSpy.mock.calls[1]?.[0]).toEqual(
+      "https://cdn.jsdelivr.net/npm/emojibase-data@5/en/messages.json",
+    );
+  });
+
+  it("should support a custom Emojibase URL", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const data = await getEmojiData({
+      locale: "en",
+      emojibaseUrl: "https://example.com/self-hosted-emojibase-data",
+    });
+
+    expect(data).toBeDefined();
+
+    expect(fetchSpy.mock.calls[0]?.[0]).toEqual(
+      "https://example.com/self-hosted-emojibase-data/en/data.json",
+    );
+    expect(fetchSpy.mock.calls[1]?.[0]).toEqual(
+      "https://example.com/self-hosted-emojibase-data/en/messages.json",
+    );
   });
 
   it("should save data locally", async () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -170,16 +170,31 @@ export interface EmojiPickerRootProps extends ComponentProps<"div"> {
   columns?: number;
 
   /**
-   * Which Emoji version to use, to manually control which
-   * emojis are visible regardless of the current browser's supported Emoji
-   * versions.
+   * Which {@link https://emojipedia.org/emoji-versions | Emoji version} to use,
+   * to manually control which emojis are visible regardless of the current
+   * browser's supported Emoji versions.
    *
    * @default The most recent version supported by the current browser
-   *
-   * @see
-   * {@link https://emojipedia.org/emoji-versions}
    */
   emojiVersion?: number;
+
+  /**
+   * The base URL of where the {@link https://emojibase.dev/docs/datasets/ | Emojibase data}
+   * should be fetched from, used as follows: `${emojibaseUrl}/${locale}/${file}.json`.
+   * (e.g. `${emojibaseUrl}/en/data.json`).
+   *
+   * The URL can be set to another CDN hosting the {@link https://www.npmjs.com/package/emojibase-data | `emojibase-data`}
+   * package and its raw JSON files, or to a self-hosted location. When self-hosting
+   * with a single locale (e.g. `en`), only that locale's directory needs to be hosted
+   * instead of the entire package.
+   *
+   * @example "https://unpkg.com/emojibase-data"
+   *
+   * @example "https://example.com/self-hosted-emojibase-data"
+   *
+   * @default "https://cdn.jsdelivr.net/npm/emojibase-data"
+   */
+  emojibaseUrl?: string;
 }
 
 export type EmojiPickerViewportProps = ComponentProps<"div">;

--- a/test/setup-emojibase.ts
+++ b/test/setup-emojibase.ts
@@ -1,30 +1,32 @@
 import { afterEach, beforeEach, vi } from "vitest";
 import createFetchMock from "vitest-fetch-mock";
 
-const CDN_URL_REGEX =
-  /^https?:\/\/cdn\.jsdelivr\.net\/npm\/emojibase-data@(?:latest|[\d\.]+)\/(\w+)\/(\w+\.json)$/;
+const EMOJIBASE_URL_REGEX = /\/(\w+)\/(\w+\.json)$/;
 
 const fetchMocker = createFetchMock(vi);
 fetchMocker.enableMocks();
 
+function hash(value: string) {
+  let hash = 0;
+
+  for (let i = 0; i < value.length; i++) {
+    hash = (hash << 5) - hash + value.charCodeAt(i);
+    hash |= 0;
+  }
+
+  return hash.toString(16);
+}
+
 beforeEach(() => {
-  fetchMocker.mockIf(CDN_URL_REGEX, async (req) => {
-    const [, locale, file] = req.url.match(CDN_URL_REGEX) ?? [];
+  fetchMocker.mockIf(EMOJIBASE_URL_REGEX, async (req) => {
+    const [, locale, file] = req.url.match(EMOJIBASE_URL_REGEX) ?? [];
 
-    const headers: HeadersInit = {
-      // TODO: generate randomly?
-      ETag: "abc123",
-    };
-
-    if (req.method === "HEAD") {
-      return {
-        status: 200,
-        headers,
+    if (locale === "en" && file === "data.json") {
+      const headers: HeadersInit = {
+        ETag: hash("en/data.json"),
       };
-    }
 
-    if (req.method === "GET") {
-      if (locale === "en" && file === "data.json") {
+      if (req.method === "GET") {
         const data = (await import("emojibase-data/en/data.json")).default;
         return {
           body: JSON.stringify(data),
@@ -32,15 +34,42 @@ beforeEach(() => {
         };
       }
 
-      if (locale === "en" && file === "messages.json") {
-        const data = (await import("emojibase-data/en/messages.json")).default;
+      if (req.method === "HEAD") {
         return {
-          body: JSON.stringify(data),
+          status: 200,
+          headers,
+        };
+      }
+    }
+
+    if (locale === "en" && file === "messages.json") {
+      const headers: HeadersInit = {
+        ETag: hash("en/messages.json"),
+      };
+
+      if (req.method === "GET") {
+        const messages = (await import("emojibase-data/en/messages.json"))
+          .default;
+        return {
+          body: JSON.stringify(messages),
           headers,
         };
       }
 
-      if (locale === "fr" && file === "data.json") {
+      if (req.method === "HEAD") {
+        return {
+          status: 200,
+          headers,
+        };
+      }
+    }
+
+    if (locale === "fr" && file === "data.json") {
+      const headers: HeadersInit = {
+        ETag: hash("fr/data.json"),
+      };
+
+      if (req.method === "GET") {
         const data = (await import("emojibase-data/fr/data.json")).default;
         return {
           body: JSON.stringify(data),
@@ -48,10 +77,31 @@ beforeEach(() => {
         };
       }
 
-      if (locale === "fr" && file === "messages.json") {
-        const data = (await import("emojibase-data/fr/messages.json")).default;
+      if (req.method === "HEAD") {
         return {
-          body: JSON.stringify(data),
+          status: 200,
+          headers,
+        };
+      }
+    }
+
+    if (locale === "fr" && file === "messages.json") {
+      const headers: HeadersInit = {
+        ETag: hash("fr/messages.json"),
+      };
+
+      if (req.method === "GET") {
+        const messages = (await import("emojibase-data/fr/messages.json"))
+          .default;
+        return {
+          body: JSON.stringify(messages),
+          headers,
+        };
+      }
+
+      if (req.method === "HEAD") {
+        return {
+          status: 200,
           headers,
         };
       }


### PR DESCRIPTION
This PR changes how [Emojibase data](https://emojibase.dev/docs/datasets/) is fetched:
- jsDelivr is still used as the default source but it will take `emojiVersion` into account, fetching the specified version if it's set instead of always `latest`
- a new `emojibaseUrl` prop allows replacing jsDelivr with another CDN, or setting a specific pinned version, or pointing to self-hosted [`emojibase-data`](https://www.npmjs.com/package/emojibase-data) files.