### PR TITLE
Fix return types to support TS version lower than 5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+- Fix return types to support TypeScript 5.1 and lower.
+
 ## [0.2.0] - 2025-04-02
 
 - When setting `emojiVersion` on `EmojiPicker.Root`, this version of Emojibase’s data will be fetched instead of `latest`.

--- a/src/components/emoji-picker.tsx
+++ b/src/components/emoji-picker.tsx
@@ -2,10 +2,10 @@ import {
   type CSSProperties,
   type ComponentProps,
   Fragment,
+  type JSX,
   type ChangeEvent as ReactChangeEvent,
   type FocusEvent as ReactFocusEvent,
   type MouseEvent as ReactMouseEvent,
-  type ReactNode,
   type SyntheticEvent as ReactSyntheticEvent,
   type UIEvent as ReactUIEvent,
   forwardRef,
@@ -1289,10 +1289,7 @@ const EmojiPickerSkinToneSelector = forwardRef<
  * </EmojiPicker.Root>
  * ```
  */
-function EmojiPickerLoading({
-  children,
-  ...props
-}: EmojiPickerLoadingProps): ReactNode {
+function EmojiPickerLoading({ children, ...props }: EmojiPickerLoadingProps) {
   const store = useEmojiPickerStore();
   const isLoading = useSelector(store, $isLoading);
 
@@ -1309,7 +1306,7 @@ function EmojiPickerLoading({
 
 function EmojiPickerEmptyWithSearch({
   children,
-}: { children: (props: { search: string }) => ReactNode }) {
+}: { children: (props: { search: string }) => JSX.Element }) {
   const store = useEmojiPickerStore();
   const search = useSelector(store, $search);
 
@@ -1341,10 +1338,7 @@ function EmojiPickerEmptyWithSearch({
  * </EmojiPicker.Empty>
  * ```
  */
-function EmojiPickerEmpty({
-  children,
-  ...props
-}: EmojiPickerEmptyProps): ReactNode {
+function EmojiPickerEmpty({ children, ...props }: EmojiPickerEmptyProps) {
   const store = useEmojiPickerStore();
   const isEmpty = useSelector(store, $isEmpty);
 
@@ -1395,9 +1389,7 @@ function EmojiPickerEmpty({
  * If you prefer to use a hook rather than a component,
  * {@link useActiveEmoji} is also available.
  */
-function EmojiPickerActiveEmoji({
-  children,
-}: EmojiPickerActiveEmojiProps): ReactNode {
+function EmojiPickerActiveEmoji({ children }: EmojiPickerActiveEmojiProps) {
   const activeEmoji = useActiveEmoji();
 
   return children({ emoji: activeEmoji });
@@ -1447,10 +1439,7 @@ function EmojiPickerActiveEmoji({
  * An already-built skin tone selector is also available,
  * {@link EmojiPicker.SkinToneSelector|`<EmojiPicker.SkinToneSelector />`}.
  */
-function EmojiPickerSkinTone({
-  children,
-  emoji,
-}: EmojiPickerSkinToneProps): ReactNode {
+function EmojiPickerSkinTone({ children, emoji }: EmojiPickerSkinToneProps) {
   const [skinTone, setSkinTone, skinToneVariations] = useSkinTone(emoji);
 
   return children({ skinTone, setSkinTone, skinToneVariations });

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -90,5 +90,5 @@ export function useSkinTone(
     store.set({ skinTone });
   }, []);
 
-  return [skinTone, setSkinTone, skinToneVariations] as const;
+  return [skinTone, setSkinTone, skinToneVariations];
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,7 +4,7 @@ import type {
   Locale as EmojibaseLocale,
   SkinToneKey as EmojibaseSkinToneKey,
 } from "emojibase/lib/types";
-import type { ComponentProps, ComponentType, ReactNode } from "react";
+import type { ComponentProps, ComponentType, JSX, ReactNode } from "react";
 
 type Resolve<T> = T extends (...args: unknown[]) => unknown
   ? T
@@ -226,7 +226,7 @@ export interface EmojiPickerEmptyProps
    * The content to render when no emoji is found for the current search, or
    * a render callback which receives the current search value.
    */
-  children?: ReactNode | ((props: EmojiPickerEmptyRenderProps) => ReactNode);
+  children?: ReactNode | ((props: EmojiPickerEmptyRenderProps) => JSX.Element);
 }
 
 export type EmojiPickerActiveEmojiRenderProps = {
@@ -242,7 +242,7 @@ export type EmojiPickerActiveEmojiProps = {
    * A render callback which receives the currently active emoji (either hovered or selected
    * via keyboard navigation).
    */
-  children: (props: EmojiPickerActiveEmojiRenderProps) => ReactNode;
+  children: (props: EmojiPickerActiveEmojiRenderProps) => JSX.Element;
 };
 
 export type EmojiPickerSkinToneRenderProps = {
@@ -274,5 +274,5 @@ export type EmojiPickerSkinToneProps = {
    * A render callback which receives the current skin tone and a function
    * to change it, as well as the skin tone variations of the specified emoji.
    */
-  children: (props: EmojiPickerSkinToneRenderProps) => ReactNode;
+  children: (props: EmojiPickerSkinToneRenderProps) => JSX.Element;
 };


### PR DESCRIPTION
This PR removes unnecessary return types and updates needed ones from `ReactNode` to `JSX.Element`, because TypeScript [didn't support using `ReactNode` for return types on versions lower than 5.1](https://www.totaltypescript.com/jsx-element-vs-react-reactnode).

Fixes https://github.com/liveblocks/frimousse/issues/17.