### PR TITLE
Optional sticky headers

### DIFF
--- a/site/src/components/sections/docs.tsx
+++ b/site/src/components/sections/docs.tsx
@@ -309,6 +309,13 @@ export function Docs({
           <p>The number of columns in the list.</p>
         </PropertiesListRow>
         <PropertiesListRow
+          defaultValue="true"
+          name="isSticky"
+          type="boolean"
+        >
+          <p>Whether to enable the sticky position of the category headers.</p>
+        </PropertiesListRow>
+        <PropertiesListRow
           defaultValue="the most recent version supported by the current browser"
           name="emojiVersion"
           type="number"

--- a/src/components/emoji-picker.tsx
+++ b/src/components/emoji-picker.tsx
@@ -149,6 +149,7 @@ const EmojiPickerRoot = forwardRef<HTMLDivElement, EmojiPickerRootProps>(
       onBlurCapture,
       children,
       style,
+      isSticky = true,
       ...props
     },
     forwardedRef,
@@ -159,6 +160,7 @@ const EmojiPickerRoot = forwardRef<HTMLDivElement, EmojiPickerRootProps>(
         stableOnEmojiSelect,
         validateLocale(locale),
         columns,
+        isSticky,
         validateSkinTone(skinTone),
       ),
     );
@@ -178,6 +180,10 @@ const EmojiPickerRoot = forwardRef<HTMLDivElement, EmojiPickerRootProps>(
     useLayoutEffect(() => {
       store.set({ columns });
     }, [columns]);
+
+    useLayoutEffect(() => {
+      store.set({ isSticky });
+    }, [isSticky]);
 
     useLayoutEffect(() => {
       store.set({ skinTone: validateSkinTone(skinTone) });
@@ -769,6 +775,7 @@ function listCategoryProps(
 function listCategoryHeaderProps(
   category: EmojiPickerCategory,
   sizer = false,
+  isSticky = true,
 ): WithAttributes<EmojiPickerListCategoryHeaderProps> {
   return {
     category,
@@ -777,7 +784,7 @@ function listCategoryHeaderProps(
       contain: !sizer ? "layout paint" : undefined,
       height: !sizer ? "var(--frimousse-category-header-height)" : undefined,
       pointerEvents: "auto",
-      position: "sticky",
+      position: isSticky ? "sticky" : undefined,
       top: 0,
     },
   };
@@ -913,6 +920,7 @@ const EmojiPickerListCategory = memo(
       (state) => state.data?.categories[categoryIndex],
       shallow,
     );
+    const isSticky = useSelectorKey(store, "isSticky");
 
     /* v8 ignore next 3 */
     if (!category) {
@@ -922,7 +930,11 @@ const EmojiPickerListCategory = memo(
     return (
       <div {...listCategoryProps(categoryIndex, category)}>
         <CategoryHeader
-          {...listCategoryHeaderProps({ label: category.label })}
+          {...listCategoryHeaderProps(
+            { label: category.label },
+            false,
+            isSticky,
+          )}
         />
       </div>
     );

--- a/src/store.ts
+++ b/src/store.ts
@@ -16,6 +16,7 @@ type Interaction = "keyboard" | "pointer" | "none";
 export type EmojiPickerStore = {
   locale: Locale;
   columns: number;
+  isSticky: boolean;
   skinTone: SkinTone;
   onEmojiSelect: NonNullable<EmojiPickerRootProps["onEmojiSelect"]>;
 
@@ -59,6 +60,7 @@ export function createEmojiPickerStore(
   onEmojiSelect: NonNullable<EmojiPickerRootProps["onEmojiSelect"]>,
   initialLocale: Locale,
   initialColumns: number,
+  initialIsSticky: boolean,
   initialSkinTone: SkinTone,
 ) {
   let viewportScrollY = 0;
@@ -66,6 +68,7 @@ export function createEmojiPickerStore(
   return createStore<EmojiPickerStore>((set, get) => ({
     locale: initialLocale,
     columns: initialColumns,
+    isSticky: initialIsSticky,
     skinTone: initialSkinTone,
     onEmojiSelect,
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -124,6 +124,11 @@ export interface EmojiPickerListCategoryHeaderProps
    * The category for this sticky header.
    */
   category: Category;
+
+  /**
+   * Whether to enable the sticky position of the category header.
+   */
+  isSticky?: boolean;
 }
 
 export interface EmojiPickerListEmojiProps
@@ -195,6 +200,13 @@ export interface EmojiPickerRootProps extends ComponentProps<"div"> {
    * @default "https://cdn.jsdelivr.net/npm/emojibase-data"
    */
   emojibaseUrl?: string;
+
+  /**
+   * Whether to enable the sticky position of the category headers.
+   *
+   * @default true
+   */
+  isSticky?: boolean;
 }
 
 export type EmojiPickerViewportProps = ComponentProps<"div">;


### PR DESCRIPTION
This PR adds an optional `isSticky` prop on `EmojiPicker.Root` to toggle the sticky behavior of category headers.

Closes #3 