### PR TITLE
feat: add category nav component

### DIFF
--- a/site/next-env.d.ts
+++ b/site/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/site/src/components/reactions.tsx
+++ b/site/src/components/reactions.tsx
@@ -12,36 +12,36 @@ import {
   ReactionsList,
 } from "./reactions.client";
 
-const liveblocks = new LiveblocksClient({
-  secret: process.env.LIVEBLOCKS_SECRET_KEY!,
-});
+// const liveblocks = new LiveblocksClient({
+//   secret: process.env.LIVEBLOCKS_SECRET_KEY!,
+// });
 
-async function ServerReactions() {
-  "use cache";
+// async function ServerReactions() {
+//   "use cache";
 
-  cacheLife("seconds");
+//   cacheLife("seconds");
 
-  let reactions: ReactionsJson;
+//   let reactions: ReactionsJson;
 
-  try {
-    reactions = (await liveblocks.getStorageDocument(ROOM_ID, "json"))
-      .reactions;
-  } catch {
-    reactions = DEFAULT_REACTIONS;
-  }
+//   try {
+//     reactions = (await liveblocks.getStorageDocument(ROOM_ID, "json"))
+//       .reactions;
+//   } catch {
+//     reactions = DEFAULT_REACTIONS;
+//   }
 
-  if (!reactions || Object.keys(reactions).length === 0) {
-    reactions = DEFAULT_REACTIONS;
-  }
+//   if (!reactions || Object.keys(reactions).length === 0) {
+//     reactions = DEFAULT_REACTIONS;
+//   }
 
-  return <ClientReactions roomId={ROOM_ID} serverReactions={reactions} />;
-}
+//   return <ClientReactions roomId={ROOM_ID} serverReactions={reactions} />;
+// }
 
 export function Reactions(props: Omit<ComponentProps<"div">, "children">) {
   return (
     <ReactionsList {...props}>
       <Suspense fallback={<FallbackReactions />}>
-        <ServerReactions />
+        {/* <ServerReactions /> */}
       </Suspense>
     </ReactionsList>
   );

--- a/site/src/examples/usage/usage.client.tsx
+++ b/site/src/examples/usage/usage.client.tsx
@@ -19,6 +19,17 @@ function EmojiPicker({ className, columns, ...props }: EmojiPickerRootProps) {
       {...props}
     >
       <EmojiPickerPrimitive.Search className="focusable z-10 mx-2 mt-2 appearance-none rounded-md bg-neutral-100 px-2.5 py-2 text-sm dark:bg-neutral-800" />
+      <EmojiPickerPrimitive.CategoryNav>
+        {({ categories }) => (
+          <div className="mx-2 mt-2 px-1 flex gap-2 overflow-x-auto max-w-[38ch] text-xs">
+            {categories.map(({ category, scrollTo }) => (
+              <button key={category.label} type="button" onClick={scrollTo} className="bg-neutral-100 hover:bg-neutral-200 dark:bg-neutral-800 hover:dark:bg-neutral-700 px-2 rounded-sm flex items-center leading-6 text-nowrap">
+                {category.label}
+              </button>
+            ))}
+          </div>
+        )}
+      </EmojiPickerPrimitive.CategoryNav>
       <EmojiPickerPrimitive.Viewport className="scrollbar-track-[transparent] scrollbar-thumb-neutral-500/30 dark:scrollbar-thumb-neutral-400/30 relative flex-1 outline-hidden">
         <EmojiPickerPrimitive.Loading className="absolute inset-0 flex items-center justify-center text-neutral-400 text-sm dark:text-neutral-500">
           Loading…

--- a/site/src/examples/usage/usage.tsx
+++ b/site/src/examples/usage/usage.tsx
@@ -26,13 +26,24 @@ export function Usage({
             children: (
               <CodeBlock className="absolute inset-0 rounded-none" lang="tsx">{`
                 "use client";
-      
+
                 import { EmojiPicker } from "frimousse";
 
                 export function MyEmojiPicker() {
                   return (
                     <EmojiPicker.Root className="isolate flex h-[368px] w-fit flex-col bg-white dark:bg-neutral-900">
                       <EmojiPicker.Search className="z-10 mx-2 mt-2 appearance-none rounded-md bg-neutral-100 px-2.5 py-2 text-sm dark:bg-neutral-800" />
+                      <EmojiPickerPrimitive.CategoryNav>
+                        {({ categories }) => (
+                          <div>
+                            {categories.map(({ category, scrollTo }) => (
+                              <button key={category.label} onClick={scrollTo}>
+                                {category.label}
+                              </button>
+                            ))}
+                          </div>
+                        )}
+                      </EmojiPickerPrimitive.CategoryNav>
                       <EmojiPicker.Viewport className="relative flex-1 outline-hidden">
                         <EmojiPicker.Loading className="absolute inset-0 flex items-center justify-center text-neutral-400 text-sm dark:text-neutral-500">
                           Loading…

--- a/src/components/emoji-picker.tsx
+++ b/src/components/emoji-picker.tsx
@@ -40,6 +40,7 @@ import type {
   EmojiData,
   EmojiPickerActiveEmojiProps,
   EmojiPickerCategory,
+  EmojiPickerCategoryNavProps,
   EmojiPickerDataCategory,
   EmojiPickerEmoji,
   EmojiPickerEmptyProps,
@@ -1452,6 +1453,64 @@ function EmojiPickerSkinTone({ children, emoji }: EmojiPickerSkinToneProps) {
   return children({ skinTone, setSkinTone, skinToneVariations });
 }
 
+/**
+ * Exposes the emoji categories and provides scroll handlers to navigate
+ * to each category via a render callback.
+ *
+ * @example
+ * ```tsx
+ * <EmojiPicker.CategoryNav>
+ *   {({ categories }) => (
+ *     <div>
+ *       {categories.map(({ category, scrollTo }) => (
+ *         <button key={category.label} onClick={scrollTo}>
+ *           {category.label}
+ *         </button>
+ *       ))}
+ *     </div>
+ *   )}
+ * </EmojiPicker.CategoryNav>
+ * ```
+ *
+ * This component allows building custom category navigation that can scroll
+ * to the corresponding section in the emoji list.
+ */
+function EmojiPickerCategoryNav({
+  children,
+}: EmojiPickerCategoryNavProps) {
+  const store = useEmojiPickerStore();
+  const data = useSelectorKey(store, "data");
+  const viewportRef = useSelectorKey(store, "viewportRef");
+  const rowHeight = useSelectorKey(store, "rowHeight");
+  const categoryHeaderHeight = useSelectorKey(store, "categoryHeaderHeight");
+
+  const categories = useMemo(() => {
+    if (!data?.categories || !viewportRef || !rowHeight || !categoryHeaderHeight) {
+      return [];
+    }
+
+    return data.categories.map((category, index) => ({
+      category: { label: category.label },
+      scrollTo: () => {
+        const viewport = viewportRef.current;
+
+        if (!viewport) {
+          return;
+        }
+
+        const scrollTop =
+          index * categoryHeaderHeight + category.startRowIndex * rowHeight;
+
+        viewport.scrollTo({
+          top: scrollTop,
+        });
+      },
+    }));
+  }, [data?.categories, viewportRef, rowHeight, categoryHeaderHeight]);
+
+  return children({ categories });
+}
+
 EmojiPickerRoot.displayName = "EmojiPicker.Root";
 EmojiPickerSearch.displayName = "EmojiPicker.Search";
 EmojiPickerViewport.displayName = "EmojiPicker.Viewport";
@@ -1461,10 +1520,12 @@ EmojiPickerEmpty.displayName = "EmojiPicker.Empty";
 EmojiPickerSkinToneSelector.displayName = "EmojiPicker.SkinToneSelector";
 EmojiPickerActiveEmoji.displayName = "EmojiPicker.ActiveEmoji";
 EmojiPickerSkinTone.displayName = "EmojiPicker.SkinTone";
+EmojiPickerCategoryNav.displayName = "EmojiPicker.CategoryNav";
 
 export {
   EmojiPickerRoot as Root, //                         <EmojiPicker.Root />
   EmojiPickerSearch as Search, //                     <EmojiPicker.Search />
+  EmojiPickerCategoryNav as CategoryNav, //           <EmojiPicker.CategoryNav />
   EmojiPickerViewport as Viewport, //                 <EmojiPicker.Viewport />
   EmojiPickerList as List, //                         <EmojiPicker.List />
   EmojiPickerLoading as Loading, //                   <EmojiPicker.Loading />

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ export type {
   Category,
   Emoji,
   EmojiPickerActiveEmojiProps,
+  EmojiPickerCategoryNavProps,
   EmojiPickerEmptyProps,
   EmojiPickerListCategoryHeaderProps,
   EmojiPickerListComponents,

--- a/src/types.ts
+++ b/src/types.ts
@@ -283,3 +283,28 @@ export type EmojiPickerSkinToneProps = {
    */
   children: (props: EmojiPickerSkinToneRenderProps) => ReactNode;
 };
+
+export type EmojiPickerCategoryNavRenderProps = {
+  /**
+   * An array of categories with their labels and scroll handlers.
+   */
+  categories: {
+    /**
+     * The category information.
+     */
+    category: Category;
+
+    /**
+     * A function to scroll the viewport to this category.
+     */
+    scrollTo: () => void;
+  }[];
+};
+
+export type EmojiPickerCategoryNavProps = {
+  /**
+   * A render callback which receives an array of categories with their
+   * labels and scroll handlers.
+   */
+  children: (props: EmojiPickerCategoryNavRenderProps) => ReactNode;
+};


### PR DESCRIPTION
## Overview

Hi team, just wanted to get the ball rolling with the implementation for https://github.com/liveblocks/frimousse/issues/7

Very much a rough draft atm, would just love some light guidance on which direction to take this (namely sourcing the icons)

@marcbouchenoire 


https://github.com/user-attachments/assets/437a570a-ed36-4113-af20-30a777f64997


## Discussion points

1. Did not use any icons yet, are there any preferences here for which icons to choose and where to keep a map of them?
2. This is most likely a separate issue - but could we make the `site/src/components/reactions.tsx` configurable locally, so the Liveblocks key wouldn't be necessary? Currently have to comment out the `<ServerReactions />` component and `LiveblocksClient()` to test things
3. Is the current implementation a bit too primitive and leaves too much for the user to configure? If we had a fixed list of icons, I guess users could just add `<EmojiPickerPrimitive.CategoryNav />` & we could remove the need to pass any children
4. The buttons are currently just a table of contents, but I think they should rather be a scroll guide, where the category icon activates depending on which section you've scrolled to (even if the scrolling happens outside of the nav)? 

## Market research
- Slack shows each category as their own page (meaning if you clicked on Animals, you cannot scroll to another category)
- EmojiMart uses the category quick-nav as a "scroll guide" as mentioned above, so you can scroll through all the categories manually and the category icons will show which category you're under (I like this a lot more than Slack's approach)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces `EmojiPicker.CategoryNav` with scrolling to categories, updates examples to use it, and disables server reactions in the site for local testing.
> 
> - **Emoji Picker**:
>   - **New `CategoryNav`**: Implements `EmojiPicker.CategoryNav` exposing categories with `scrollTo` handlers.
>   - **Types/Exports**: Adds `EmojiPickerCategoryNavProps` and related render props; re-exports from `src/index.ts`.
> - **Examples**:
>   - Integrates `CategoryNav` into usage examples (`site/src/examples/usage/*`).
> - **Site (dev convenience)**:
>   - Comments out server reactions/Liveblocks client in `site/src/components/reactions.tsx`.
>   - Adjusts Next.js type import in `site/next-env.d.ts` to `./.next/dev/types/routes.d.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4a5de1879899350999442eceecaca076f64055e8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->